### PR TITLE
add parameters to ignore to work around breaking existing connections

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -7,6 +7,7 @@ resource "azurerm_logic_app_workflow" "logicapp" {
   lifecycle {
     ignore_changes = [
       tags,
+      parameters
     ]
   }
 


### PR DESCRIPTION
This is a workaround to ignore parameters when updating logic apps in order to avoid breaking established API connections.  This module is still being developed and specific parameters will be added in the future to minimize the impact.